### PR TITLE
Switch jinja2 to django templating

### DIFF
--- a/ndlug/settings.py
+++ b/ndlug/settings.py
@@ -60,8 +60,7 @@ ROOT_URLCONF = 'ndlug.urls'
 
 TEMPLATES = [
     {
-        #'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'BACKEND':'django.template.backends.django.DjangoTemplates',
+        'BACKEND':'django.template.backends.jinja2.Jinja2',
         'DIRS': [os.path.join(BASE_DIR, 'templates')],
         'APP_DIRS': True,
         'OPTIONS': {
@@ -71,14 +70,6 @@ TEMPLATES = [
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
             ],
-        },
-    },
-    {
-        'BACKEND':'django.template.backends.jinja2.Jinja2',
-        'DIRS':[],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            
         },
     },
 ]

--- a/ndlug/settings.py
+++ b/ndlug/settings.py
@@ -41,7 +41,6 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'django_jinja',
     'announcements',
    # 'polls',
 ]


### PR DESCRIPTION
There's not any particular reason for us to use jinja2 over django templates. 